### PR TITLE
Remove extra colon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yo llvm:pass append
 ```
 If you like to stay on bleeding edge and want to try the new PassManager pass, add the `--new-pm` at the tail:
 ```
-yo llvm::pass init --new-pm
+yo llvm:pass init --new-pm
 # Same option applies to the "append" command as well
 ```
 The generated pass is also loaded as an external plugin. Please refer to [this article](https://medium.com/@mshockwave/writing-llvm-pass-in-2018-part-i-531c700e85eb) I wrote about how to run a new PassManager pass.


### PR DESCRIPTION
Your readme has one too many colons in generate pass with the new pass manager line