### PR TITLE
LLVM 12.0.1 needs C++14

### DIFF
--- a/executable/templates/CMakeLists.txt
+++ b/executable/templates/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION <%= minCmakeVer %>)
 project(<%= topProjectName %>)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 set(LLVM_DIST_PATH "<%= llvmInstallDir %>"
         CACHE STRING "LLVM distribution install path")


### PR DESCRIPTION
I had to bump the C++ standard from 11 to 14 to get a clean compile when targeting LLVM 12.0.1